### PR TITLE
Prevent crash if an null cell is passed to `format_hyperlink`

### DIFF
--- a/xlsx2html/format/hyperlink.py
+++ b/xlsx2html/format/hyperlink.py
@@ -46,6 +46,9 @@ def resolve_hyperlink_formula(cell, f_cell):
 
 
 def format_hyperlink(value, cell, f_cell=None):
+    if cell is None:
+        return value
+
     hyperlink = HyperlinkType(title=value)
 
     if cell.hyperlink:


### PR DESCRIPTION
We ran into an issue where a `format_hyperlink` threw an exception: `AttributeError: 'NoneType' object has no attribute 'hyperlink'`.  Reading the code, it seems possible that `cell` can be a `None` value and this is not correctly accounted for in `format_hyperlink`.

I'm not entirely sure what we should return when we hit this situation, but returning the value seemed reasonable.

